### PR TITLE
fix(utils.oauth2): support sha256 hashing in non-secure (https) browser environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "browser-acl": "^1.0.2",
     "cf-agent-library": "git+https://git@github.com/CrisisCleanup/cf-agent-library.git",
     "color": "^4.2.3",
+    "crypto-js": "^4.1.1",
     "d3": "^7.8.5",
     "d3-array": "^2.12.1",
     "d3-color": "^1.4.1",
@@ -132,6 +133,7 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@playwright/test": "^1.35.1",
+    "@types/crypto-js": "^4.1.1",
     "@types/d3": "^7.4.0",
     "@types/google.maps": "^3.53.4",
     "@types/leaflet": "^1.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ dependencies:
   color:
     specifier: ^4.2.3
     version: 4.2.3
+  crypto-js:
+    specifier: ^4.1.1
+    version: 4.1.1
   d3:
     specifier: ^7.8.5
     version: 7.8.5
@@ -286,6 +289,9 @@ devDependencies:
   '@playwright/test':
     specifier: ^1.35.1
     version: 1.35.1
+  '@types/crypto-js':
+    specifier: ^4.1.1
+    version: 4.1.1
   '@types/d3':
     specifier: ^7.4.0
     version: 7.4.0
@@ -3298,6 +3304,10 @@ packages:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
     dev: true
 
+  /@types/crypto-js@4.1.1:
+    resolution: {integrity: sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==}
+    dev: true
+
   /@types/d3-array@3.0.4:
     resolution: {integrity: sha512-nwvEkG9vYOc0Ic7G7kwgviY4AQlTfYGIZ0fqB7CQHXGyYM6nO7kJh5EguSNA3jfh4rq7Sb7eMVq8isuvg2/miQ==}
     dev: true
@@ -4860,6 +4870,10 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /crypto-js@4.1.1:
+    resolution: {integrity: sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==}
+    dev: false
 
   /css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}

--- a/src/utils/oauth.ts
+++ b/src/utils/oauth.ts
@@ -1,26 +1,14 @@
-const crypto = window.crypto || (window as any).msCrypto;
+import sha256 from 'crypto-js/sha256';
+import Base64Url from 'crypto-js/enc-base64url';
 
 export function generateRandomString(): string {
   const array = new Uint32Array(28);
+  const crypto = window.crypto || (window as any).msCrypto;
   crypto.getRandomValues(array);
   return [...array].map((dec) => ('0' + dec.toString(16)).slice(-2)).join('');
 }
 
-function sha256(plain: string): Promise<ArrayBuffer> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(plain);
-  return crypto.subtle.digest('SHA-256', data);
-}
-
-function base64urlencode(a: ArrayBuffer): string {
-  const uintArray = new Uint8Array(a);
-  const array = [...uintArray];
-  const str = String.fromCharCode.apply(null, array);
-  const base64 = btoa(str);
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}
-
 export async function pkceChallengeFromVerifier(v: string): Promise<string> {
-  const hashed = await sha256(v);
-  return base64urlencode(hashed);
+  const hashed = sha256(v);
+  return Base64Url.stringify(hashed);
 }


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the title above

NOTE: Please uncomment (Ctrl/Cmd + /) the header lines if
you have that information about the pull request
-->

<!--
- Describe your changes in detail
- What does this pull request add/fix? Explain your changes.
-->

## Description

- feat(deps): add crypto-js
- fix(utils.oauth2): support sha256 hashing in non-secure (http) environments

### Current Behavior

Authorization code flow fails during local development because web crypto subtle api is only available in secure (https) environments.
We only need this to perform the sha256 hash.
See: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto

### New Behavior

No longer requires https to succeed in local/non-secure env due to sha256 hash.

## Pull Request Type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes

<!--
- Go over all the following points, and put an `x` in all the boxes that apply.
- If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
