### PR TITLE
fix(svislider): re added back return if 100

### DIFF
--- a/src/pages/Work.vue
+++ b/src/pages/Work.vue
@@ -1260,6 +1260,7 @@ export default defineComponent({
 
     function filterSvi(value: number) {
       sviSliderValue.value = Number(value);
+      if (value === 100) return;
       const layer = mapUtils?.getCurrentMarkerLayer();
       const container = layer?._pixiContainer;
       const sviList = getSviList(container?.children?.length);


### PR DESCRIPTION
added back 100 return so that the filter shows all if 100, currently this causes the userstates to not be taken into account on each load