### PR TITLE
fix(pages/admin/rag): accomodate changes made to `inform` icon used in rag message tools window

### DIFF
--- a/src/pages/admin/AdminRAG.vue
+++ b/src/pages/admin/AdminRAG.vue
@@ -507,9 +507,10 @@ const moveFile = async (documentFile: CCUDocumentFileItem) => {
             <div v-if="h.tools" class="float-right">
               <ccu-icon
                 type="info"
-                size="md"
+                size="lg"
                 title="Info"
                 class="hover:bg-crisiscleanup-light-grey transition-all cursor-pointer hover:scale-105"
+                icon-classes="invert"
                 @click="() => displayMessageTools(h)"
               />
             </div>


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the title above

NOTE: Please uncomment (Ctrl/Cmd + /) the header lines if
you have that information about the pull request
-->

<!--
- Describe your changes in detail
- What does this pull request add/fix? Explain your changes.
-->

## Description

`inform.svg` icon was recently inverted / edited.
This caused prevented it from being visible in rag messages since the new icon is now the same color as the background where its used.
This just updates the usage to invert the icon color and increase the size.
