### PR TITLE
fix(login): image link for logo

### DIFF
--- a/src/layouts/Home.vue
+++ b/src/layouts/Home.vue
@@ -4,7 +4,7 @@
       <div class="w-40 md:w-52">
         <a href="/live">
           <img
-            src="../assets/ccu-logo-black-500w.png"
+            src="@/assets/ccu-logo-black-500w.png"
             data-testid="testLogoIcon"
             alt="Crisis Cleanup"
           />


### PR DESCRIPTION
Since the issue was primarily in staging and in prod I believe that the issue mainly is the pathing for the link for the logo. I changed the path to be based on the src folder instead of using ../assets which might have caused problems