### PR TITLE
feat: added textarea resize to baseinput

### DIFF
--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -105,6 +105,10 @@ import { ref, computed, defineComponent } from 'vue';
 export default defineComponent({
   name: 'BaseInput',
   props: {
+    textAreaAutoResize: {
+      type: Boolean,
+      default: false,
+    },
     size: {
       type: String,
       default: '',
@@ -243,6 +247,7 @@ export default defineComponent({
       'has-tooltip': Boolean(props.tooltip),
       invalid: Boolean(isInvalid.value),
       'border-none': Boolean(props.topLabel),
+      noscrollbars: Boolean(props.textAreaAutoResize),
     }));
 
     function update(e) {
@@ -255,12 +260,29 @@ export default defineComponent({
           return context.emit('update:modelValue', newValue);
         }
       }
-
+      if (props.textAreaAutoResize) {
+        textAreaAutoResize();
+      }
       context.emit('update:modelValue', value);
       isInvalid.value = !input?.value?.checkValidity();
       return value;
     }
 
+    function textAreaAutoResize() {
+      nextTick(() => {
+        const element = input.value;
+        if (
+          props.textArea &&
+          element &&
+          element.scrollHeight > element.clientHeight
+        ) {
+          element.style.height = `${element.scrollHeight}px`;
+        }
+        // element.style.height = "auto";  // Reset the height to recalculate
+        //const heightLimit = 200;  // Maximum height
+        //element.style.height = `${Math.min(element.scrollHeight, heightLimit)}px`;
+      });
+    }
     function change(e) {
       context.emit('change', e.target.value);
       isInvalid.value = !input?.value?.checkValidity();
@@ -308,6 +330,11 @@ textarea.invalid {
   @apply border border-crisiscleanup-red-100;
 }
 
+textarea.noscrollbars {
+  overflow: hidden;
+  width: 300px;
+  height: 100px;
+}
 input {
   outline: none;
   width: var(--width);

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -278,9 +278,6 @@ export default defineComponent({
         ) {
           element.style.height = `${element.scrollHeight}px`;
         }
-        // element.style.height = "auto";  // Reset the height to recalculate
-        //const heightLimit = 200;  // Maximum height
-        //element.style.height = `${Math.min(element.scrollHeight, heightLimit)}px`;
       });
     }
     function change(e) {

--- a/src/components/work/WorksiteNotes.vue
+++ b/src/components/work/WorksiteNotes.vue
@@ -89,9 +89,10 @@
       <base-input
         text-area
         data-testid="testCurrentNoteTextarea"
+        text-area-auto-resize
         :value="currentNote"
         :rows="3"
-        @update:modelValue="
+        @update:model-value="
           (value) => {
             currentNote = value;
             $emit('input', value);


### PR DESCRIPTION
Make Worksite Notes Field Grow when Typing #796 

@aarontitus @deepanchal 


Previous behavior: The text input field for notes was too small and included scrollbars, lacking the ability to auto-resize.
reference video: https://gyazo.com/2216bf02cc23942f9883dfd7219a1ca0

New behavior: The BaseInput component now features an optional textAreaResize boolean that enables auto-resizing for text areas. Consequently, the text areas for notes on worksites and phone now automatically adjust in size as the user types.
reference video: https://gyazo.com/2216bf02cc23942f9883dfd7219a1ca0

