### PR TITLE
feat(ui): improve map components and introduce Command Center dashboard

### DIFF
--- a/src/components/SimpleMap.vue
+++ b/src/components/SimpleMap.vue
@@ -92,7 +92,7 @@
       />
     </div>
     <WorksiteLegend
-      v-if="showZoomButtons || showLegend"
+      v-if="(showZoomButtons && !removeLegend) || showLegend"
       :key="availableWorkTypes"
       class="hidden md:block"
       data-testid="testShowLegendDiv"
@@ -119,6 +119,9 @@ export default defineComponent({
       type: Boolean,
     },
     showLegend: {
+      type: Boolean,
+    },
+    removeLegend: {
       type: Boolean,
     },
     availableWorkTypes: {

--- a/src/components/WorkTypeMap.vue
+++ b/src/components/WorkTypeMap.vue
@@ -2,7 +2,6 @@
   <div class="relative">
     <div
       id="map"
-      ref="map"
       data-testid="testWorkTypeMapDiv"
       class="absolute top-0 left-0 right-0 bottom-0"
     ></div>
@@ -50,11 +49,9 @@ export default defineComponent({
     };
 
     const renderMap = async (markers: Record<string, any>[]) => {
-      if (!map.value) {
-        map.value = L.map('map', {
-          zoomControl: false,
-        }).setView([35.746_512_259_918_5, -96.411_509_631_256_56], 10);
-      }
+      map.value = L.map('map', {
+        zoomControl: false,
+      }).setView([35.746_512_259_918_5, -96.411_509_631_256_56], 10);
 
       L.tileLayer(mapTileLayer, {
         // tileSize: 512,
@@ -121,9 +118,9 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
+<style>
 .leaflet-data-marker svg {
-  width: 30px;
-  height: 30px;
+  width: 20px;
+  height: 20px;
 }
 </style>

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="divide-y divide-gray-200">
+  <div :class="classes">
     <slot :icon-style="iconStyle"></slot>
   </div>
 </template>
@@ -11,6 +11,10 @@ export default {
     iconStyle: {
       type: String,
       default: 'chevron', // Options: 'chevron', 'plus-minus'
+    },
+    classes: {
+      type: String,
+      default: 'divide-y divide-gray-200',
     },
   },
 };

--- a/src/components/accordion/AccordionItem.vue
+++ b/src/components/accordion/AccordionItem.vue
@@ -1,10 +1,18 @@
 <template>
   <div :class="classes">
     <button :class="buttonClasses" @click="toggleOpen">
+      <font-awesome-icon
+        v-if="iconPosition === 'left'"
+        :icon="isOpen ? openIcon : closedIcon"
+        size="xs"
+      />
       <slot name="name">
         {{ name }}
       </slot>
-      <font-awesome-icon :icon="isOpen ? openIcon : closedIcon" />
+      <font-awesome-icon
+        v-if="iconPosition === 'right'"
+        :icon="isOpen ? openIcon : closedIcon"
+      />
     </button>
     <div v-show="isOpen" :class="bodyClasses">
       <slot></slot>
@@ -39,6 +47,10 @@ export default {
       type: String,
       default: 'chevron', // Options: 'chevron', 'plus-minus'
     },
+    iconPosition: {
+      type: String,
+      default: 'right', // Options: 'left', 'right'
+    },
     classes: {
       type: String,
       default: 'border-b border-gray-200',
@@ -52,10 +64,14 @@ export default {
       type: String,
       default: 'py-2 px-4',
     },
+    startOpen: {
+      type: Boolean,
+      default: false,
+    },
   },
   setup(props) {
     const state = reactive({
-      isOpen: false,
+      isOpen: props.startOpen,
     });
 
     const toggleOpen = () => {

--- a/src/components/dashboard/TeamCompletion.vue
+++ b/src/components/dashboard/TeamCompletion.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="status-card border rounded p-4 shadow">
+    <!-- Percentage and Links -->
+    <div class="flex items-center justify-between">
+      <div class="text-6xl font-bold">
+        {{ completionPercentage }}<span class="text-2xl">%</span>
+      </div>
+      <div class="text-right">
+        <a href="#" class="text-blue-600"
+          >{{ closedCases }} {{ $t('~~cases closed') }}</a
+        ><br />
+        <a href="#" class="text-blue-600"
+          >{{ openCases }} {{ $t('~~open cases') }}</a
+        ><br />
+        <a href="#" class="text-blue-600"
+          >{{ overdueCases }} {{ $t('~~overdue cases') }}</a
+        >
+      </div>
+    </div>
+
+    <!-- Progress Bar -->
+    <div class="my-4">
+      <div class="relative w-full h-4 rounded bg-gray-200">
+        <div
+          class="absolute left-0 h-4 rounded-l"
+          :style="{ width: closedWidth, backgroundColor: '#8dd362' }"
+        ></div>
+        <div
+          class="absolute h-4"
+          :style="{
+            left: closedWidth,
+            width: inProgressWidth,
+            backgroundColor: '#f2b85d',
+          }"
+        ></div>
+        <div
+          class="absolute h-4"
+          :style="{
+            left: `${parseFloat(closedWidth) + parseFloat(inProgressWidth)}%`,
+            width: overdueWidth,
+            backgroundColor: '#f05454',
+          }"
+        ></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  teams: {
+    type: Array,
+    required: true,
+  },
+});
+
+const closedCases = computed(() => {
+  return props.teams.reduce((acc, team) => {
+    return (
+      acc +
+      team.assigned_work_types.filter((workType) =>
+        workType.status.includes('closed'),
+      ).length
+    );
+  }, 0);
+});
+
+const openCases = computed(() => {
+  return props.teams.reduce((acc, team) => {
+    return (
+      acc +
+      team.assigned_work_types.filter((workType) =>
+        workType.status.includes('open'),
+      ).length
+    );
+  }, 0);
+});
+
+const overdueCases = computed(() => {
+  return props.teams.reduce((acc, team) => {
+    return (
+      acc +
+      team.assigned_work_types.filter(
+        (workType) => workType.status === 'open_unassigned',
+      ).length
+    );
+  }, 0);
+});
+
+const completionPercentage = computed(() => {
+  const totalCases = closedCases.value + openCases.value + overdueCases.value;
+  return totalCases ? Math.round((closedCases.value / totalCases) * 100) : 0;
+});
+
+const closedWidth = computed(() => {
+  const totalCases = closedCases.value + openCases.value + overdueCases.value;
+  return `${(closedCases.value / totalCases) * 100}%`;
+});
+
+const inProgressWidth = computed(() => {
+  const totalCases = closedCases.value + openCases.value + overdueCases.value;
+  return `${(openCases.value / totalCases) * 100}%`;
+});
+
+const overdueWidth = computed(() => {
+  const totalCases = closedCases.value + openCases.value + overdueCases.value;
+  return `${(overdueCases.value / totalCases) * 100}%`;
+});
+</script>
+
+<style scoped></style>

--- a/src/components/locations/LayerUploadTool.vue
+++ b/src/components/locations/LayerUploadTool.vue
@@ -309,9 +309,6 @@ export default defineComponent({
             },
           },
         );
-        if (result instanceof AxiosError) {
-          return $toasted.error(getErrorMessage(result));
-        }
         emit('addedLayer', result.data);
         $toasted.success(t('layersVue.successful_upload'));
       } catch (error) {

--- a/src/components/work/WorksiteView.vue
+++ b/src/components/work/WorksiteView.vue
@@ -698,9 +698,6 @@ export default defineComponent({
           workTypes,
           reason,
         );
-        if (result.response instanceof AxiosError) {
-          return $toasted.error(getErrorMessage(result.response));
-        }
         await Worksite.api().fetch(props.worksiteId);
         await getWorksiteRequests();
         emit('reloadMap', props.worksiteId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { version } from '@/../package.json';
 import { createApp, type App as VueApp } from 'vue';
 import './style.css';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import VueTagsInput from '@sipec/vue3-tags-input';
@@ -56,12 +56,21 @@ import BaseRadio from './components/BaseRadio.vue';
 import Unauthenticated from './layouts/Unauthenticated.vue';
 import BaseLink from './components/BaseLink.vue';
 import TreeMenu from '@/components/TreeMenu.vue';
+import { getAndToastErrorMessage } from '@/utils/errors';
 
 library.add(fas);
 library.add(far);
 
 axios.defaults.withCredentials = true;
-
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    // Here, you can ensure that Axios always throws an AxiosError
+    if (error instanceof AxiosError) {
+      return getAndToastErrorMessage(error);
+    }
+  },
+);
 const buildApp = (app: VueApp) =>
   app
     .component('FontAwesomeIcon', FontAwesomeIcon as any)

--- a/src/models/PhoneOutbound.ts
+++ b/src/models/PhoneOutbound.ts
@@ -159,10 +159,6 @@ export default class PhoneOutbound extends CCUModel {
           ),
         );
 
-        if (resp.response instanceof AxiosError) {
-          throw new TypeError(getErrorMessage(resp.response));
-        }
-
         const [outbound] = resp.entities.phone_outbound || [];
         return outbound;
       },

--- a/src/models/Team.ts
+++ b/src/models/Team.ts
@@ -13,6 +13,7 @@ export default class Team extends CCUModel {
   assigned_work_types!: WorkType[];
   cases_area!: Record<string, unknown>;
   incident!: Incident;
+  organization!: string;
 
   static fields() {
     return {
@@ -23,6 +24,7 @@ export default class Team extends CCUModel {
       assigned_work_types: this.attr([]),
       cases_area: this.attr({}),
       incident: this.attr(null),
+      organization: this.attr(''),
     };
   }
 

--- a/src/pages/dashboards/CommandCenterDashboard.vue
+++ b/src/pages/dashboards/CommandCenterDashboard.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import type Team from '@/models/Team';
+import Organization from '@/models/Organization';
+import axios from 'axios';
+import Accordion from '@/components/accordion/Accordion.vue';
+import AccordionItem from '@/components/accordion/AccordionItem.vue';
+import useWorksiteMap from '@/hooks/worksite/useWorksiteMap';
+import { getWorksites, getDashboardStatistics } from '@/utils/dashboard';
+import { useCurrentIncident, useCurrentUser } from '@/hooks';
+import SimpleMap from '@/components/SimpleMap.vue';
+import { useDashboardActionItems } from '@/hooks/useDashboardActionItems';
+import * as L from 'leaflet';
+import { INTERACTIVE_ZOOM_LEVEL } from '@/constants';
+import Incident from '@/models/Incident';
+import { nFormatter } from '@/utils/helpers';
+import TeamCompletion from '@/components/dashboard/TeamCompletion.vue';
+
+const { currentIncidentId, currentIncident } = useCurrentIncident();
+const { currentUser } = useCurrentUser();
+
+const affiliatedTeams = ref<Team[]>([]);
+const dashboardStatistics = ref<Record<string, any>>({});
+let mapUtils;
+
+const { loadingActionItems } = useDashboardActionItems(
+  currentIncidentId.value,
+  currentUser.value?.organization.id,
+  currentUser.value,
+);
+
+const getAffiliates = async () => {
+  const response = await axios.get(
+    `${import.meta.env.VITE_APP_API_BASE_URL}/affiliated_teams`,
+  );
+  affiliatedTeams.value = response.data.results;
+
+  if (affiliatedTeams.value.length > 0) {
+    await Organization.api().get(
+      `/organizations?id__in=${affiliatedTeams.value
+        .map((team) => team.organization)
+        .join(',')}`,
+      {
+        dataKey: 'results',
+      },
+    );
+  }
+};
+
+const teamsByOrganization = computed(() => {
+  const teamsByOrg = {} as Record<string, Team[]>;
+  for (const team of affiliatedTeams.value) {
+    if (!teamsByOrg[team.organization]) {
+      teamsByOrg[team.organization] = [];
+    }
+    teamsByOrg[team.organization].push(team);
+  }
+  return teamsByOrg;
+});
+
+const getOrganizationName = (organizationId: string) => {
+  const organization = Organization.find(organizationId);
+  return organization ? organization.name : '';
+};
+
+function zoomIn() {
+  mapUtils?.getMap().zoomIn();
+}
+
+function zoomOut() {
+  mapUtils?.getMap().zoomOut();
+}
+
+function getIncidentCenter() {
+  const { incident_center } = Incident.find(
+    currentIncidentId.value,
+  ) as Incident;
+  if (incident_center) {
+    return [incident_center.coordinates[1], incident_center.coordinates[0]];
+  }
+  return [35.746_512_259_918_5, -96.411_509_631_256_56];
+}
+
+function goToIncidentCenter() {
+  mapUtils?.getMap().setView(getIncidentCenter(), 6);
+}
+
+function goToInteractive() {
+  mapUtils?.getMap().setView(getIncidentCenter(), INTERACTIVE_ZOOM_LEVEL);
+}
+
+onMounted(async () => {
+  await getAffiliates();
+  getWorksites(currentIncidentId.value).then((worksites) => {
+    mapUtils = useWorksiteMap(
+      worksites,
+      worksites.map((m) => m.id),
+      () => {},
+      (_, map) => {
+        if (currentIncident.incident_center) {
+          map.setView(
+            [
+              currentIncident.incident_center.coordinates[1],
+              currentIncident.incident_center.coordinates[0],
+            ],
+            INTERACTIVE_ZOOM_LEVEL,
+          );
+        } else {
+          map.setView([35.746_512_259_918_5, -96.411_509_631_256_56], 5);
+        }
+        for (let team of affiliatedTeams.value) {
+          L.geoJson(team.cases_area, {
+            color: team.color,
+          }).addTo(map);
+        }
+      },
+    );
+  });
+  getDashboardStatistics({ incidentId: currentIncidentId.value })
+    .then((data) => {
+      dashboardStatistics.value = data;
+    })
+    .catch((error) => {
+      console.error('Error fetching dashboard statistics:', error);
+    });
+});
+</script>
+
+<template>
+  <div class="grid md:grid-cols-2 grid-cols-1 min-h-180 gap-4">
+    <!-- Accordion on the left -->
+    <div class="p-2 overflow-x-auto">
+      <h2 class="font-semibold text-lg mb-3 flex justify-between">
+        {{ $t('~~Affiliated Organizations') }}
+      </h2>
+      <Accordion>
+        <AccordionItem
+          v-for="(teams, organization) in teamsByOrganization"
+          :key="organization"
+          :name="getOrganizationName(organization)"
+          icon-position="left"
+          button-classes="w-full text-left px-2 pt-0.5 focus:outline-none flex gap-1 items-center bg-crisiscleanup-light-smoke rounded p-0.5 font-semibold"
+          classes="text-sm"
+          body-classes="py-1"
+          start-open
+        >
+          <div class="grid grid-cols-3 text-xs gap-2">
+            <!-- Header Row -->
+            <div
+              class="col-span-3 grid gap-1 grid-cols-3 font-semibold bg-crisiscleanup-light-smoke rounded p-0.5"
+            >
+              <span class="text-gray-700">{{ $t('~~Team') }}</span>
+              <span class="text-gray-700">{{ $t('~~Size') }}</span>
+              <span class="text-gray-700">{{ $t('~~Cases') }}</span>
+            </div>
+
+            <!-- Data Rows -->
+            <template v-for="team in teams" :key="team.id">
+              <div class="col-span-3 grid gap-1 grid-cols-3">
+                <div class="flex items-center">
+                  <div
+                    class="w-2 h-2 rounded-full mr-2"
+                    :style="{ backgroundColor: team.color }"
+                  ></div>
+                  {{ team.name }}
+                </div>
+                <span>{{ team.users.length }}</span>
+                <span>{{ team.assigned_work_types.length }}</span>
+              </div>
+            </template>
+          </div>
+        </AccordionItem>
+      </Accordion>
+    </div>
+
+    <!-- Map and Statistics on the right -->
+    <div class="flex flex-col gap-4 p-2">
+      <!-- Map Section -->
+      <h2 class="font-semibold text-lg mb-3 flex justify-between">
+        {{ $t('~~Teams Disaster Map') }}
+        <router-link :to="`/incident/${currentIncidentId}/work`"
+          ><span class="text-crisiscleanup-dark-blue text-sm hover:underline">{{
+            $t('~~Go to Teams')
+          }}</span></router-link
+        >
+      </h2>
+      <div class="relative h-84">
+        <SimpleMap
+          :map-loading="loadingActionItems"
+          data-testid="testSimpleMapContent"
+          show-zoom-buttons
+          remove-legend
+          @on-zoom-in="zoomIn"
+          @on-zoom-out="zoomOut"
+          @on-zoom-incident-center="goToIncidentCenter"
+          @on-zoom-interactive="goToInteractive"
+        />
+      </div>
+
+      <!-- Statistics Section -->
+      <div v-if="dashboardStatistics" class="grid grid-cols-2 gap-2">
+        <div class="stats-card">
+          <p>{{ $t('dashboard.total_value') }}</p>
+          <p>${{ nFormatter(dashboardStatistics.total_commercial_value) }}</p>
+        </div>
+        <div class="stats-card">
+          <p>{{ $t('dashboard.members_served') }}</p>
+          <p>{{ dashboardStatistics.members_served }}</p>
+        </div>
+        <div class="stats-card">
+          <p>{{ $t('dashboard.total_cases') }}</p>
+          <p>
+            <router-link :to="`/incident/${currentIncidentId}/work`"
+              >{{ dashboardStatistics.total_cases }}
+            </router-link>
+          </p>
+        </div>
+        <div class="stats-card">
+          <p>{{ $t('dashboard.active_users_today') }}</p>
+          <p class="text-primary-dark cursor-pointer">
+            {{ dashboardStatistics.active_users_today }}
+          </p>
+        </div>
+      </div>
+
+      <div class="md:mt-6">
+        <h2 class="font-semibold text-lg mb-3 flex justify-between">
+          {{ $t('~~Completion Rate') }}
+        </h2>
+
+        <TeamCompletion :teams="affiliatedTeams" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/pages/dashboards/DashboardSelector.vue
+++ b/src/pages/dashboards/DashboardSelector.vue
@@ -27,6 +27,12 @@ const availableDashboards = [
     description: t('dashboard.phone_volunteer_description'),
     icon: 'phone-volunteer-dashboard',
   },
+  // {
+  //   name: t('dashboard.command_center'),
+  //   path: 'command-center',
+  //   description: t('dashboard.command_center_description'),
+  //   icon: 'command-center-dashboard',
+  // },
 ];
 
 const selectedDashboard = ref('');

--- a/src/pages/organization/Affiliates.vue
+++ b/src/pages/organization/Affiliates.vue
@@ -216,14 +216,16 @@ export default defineComponent({
       await Affiliate.api().get('/organization_affiliate_requests', {
         dataKey: 'results',
       });
-      await Organization.api().get(
-        `/organizations?id__in=${Affiliate.all()
-          .map((org) => org.affiliate)
-          .join(',')}`,
-        {
-          dataKey: 'results',
-        },
-      );
+      if (Affiliate.all().length > 0) {
+        await Organization.api().get(
+          `/organizations?id__in=${Affiliate.all()
+            .map((org) => org.affiliate)
+            .join(',')}`,
+          {
+            dataKey: 'results',
+          },
+        );
+      }
       loading.value = false;
     };
 

--- a/src/pages/organization/TeamDetail.vue
+++ b/src/pages/organization/TeamDetail.vue
@@ -856,9 +856,6 @@ export default defineComponent({
         `/teams/${team.value?.id}`,
         team.value?.$toJson(),
       );
-      if (result.response instanceof AxiosError) {
-        return $toasted.error(getErrorMessage(result.response));
-      }
       return $toasted.success(t('teams.team_updated'));
     };
 

--- a/src/pages/unauthenticated/InvitationSignup.vue
+++ b/src/pages/unauthenticated/InvitationSignup.vue
@@ -183,9 +183,6 @@ export default defineComponent({
             mobile,
             title,
           });
-          if (result.response instanceof AxiosError) {
-            return $toasted.error(getErrorMessage(result.response));
-          }
           await confirm({
             title: t('info.success'),
             content: t(`invitationSignup.success_accept_invitation`),

--- a/src/pages/unauthenticated/Survivors.vue
+++ b/src/pages/unauthenticated/Survivors.vue
@@ -620,9 +620,6 @@ export default defineComponent({
             },
           },
         );
-        if (result instanceof AxiosError && result.response.status === 404) {
-          $toasted.error(t('survivorContact.invalid_expired_token'));
-        }
         if (filesOnly) {
           state.survivorToken.files = result.data.files;
         } else {
@@ -633,7 +630,7 @@ export default defineComponent({
           }
         }
       } catch (error) {
-        await $toasted.error(getErrorMessage(error));
+        $toasted.error(getErrorMessage(error));
         // this.$log.debug(error);
       } finally {
         state.loading = false;

--- a/src/router.ts
+++ b/src/router.ts
@@ -40,6 +40,8 @@ const DefaultDashboard = () =>
 
 const PhoneVolunteerDashboard = () =>
   import('./pages/dashboards/PhoneVolunteerDashboard.vue');
+const CommandCenterDashboard = () =>
+  import('./pages/dashboards/CommandCenterDashboard.vue');
 const Work = () => import('./pages/Work.vue');
 const AppDownload = () => import('./pages/AppDownload.vue');
 const OtherOrganizations = () => import('@/pages/OtherOrganizations.vue');
@@ -87,6 +89,11 @@ const routes = [
         path: 'phone_volunteer',
         name: 'nav.phone_volunteer_dashboard',
         component: PhoneVolunteerDashboard,
+      },
+      {
+        path: 'command_center',
+        name: 'nav.command_center_dashboard',
+        component: CommandCenterDashboard,
       },
     ],
   },

--- a/test/unit/components/accordion/__snapshots__/AccordionItem.test.ts.snap
+++ b/test/unit/components/accordion/__snapshots__/AccordionItem.test.ts.snap
@@ -1,9 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`AccordionItem > matches snapshot when closed 1`] = `
-"<div class="border-b border-gray-200"><button class="w-full text-left bg-white py-2 px-4 hover:bg-gray-100 focus:outline-none flex justify-between items-center">Test Name<svg class="svg-inline--fa fa-chevron-right" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-right" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
+"<div class="border-b border-gray-200"><button class="w-full text-left bg-white py-2 px-4 hover:bg-gray-100 focus:outline-none flex justify-between items-center">
+    <!--v-if-->Test Name<svg class="svg-inline--fa fa-chevron-right" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-right" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512">
       <path class="" fill="currentColor" d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"></path>
-    </svg></button>
+    </svg>
+  </button>
   <div class="py-2 px-4" style="display: none;">
     <div>Inner Content</div>
   </div>
@@ -11,9 +13,11 @@ exports[`AccordionItem > matches snapshot when closed 1`] = `
 `;
 
 exports[`AccordionItem > matches snapshot when open 1`] = `
-"<div class="border-b border-gray-200"><button class="w-full text-left bg-white py-2 px-4 hover:bg-gray-100 focus:outline-none flex justify-between items-center">Test Name<svg class="svg-inline--fa fa-chevron-down" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+"<div class="border-b border-gray-200"><button class="w-full text-left bg-white py-2 px-4 hover:bg-gray-100 focus:outline-none flex justify-between items-center">
+    <!--v-if-->Test Name<svg class="svg-inline--fa fa-chevron-down" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="chevron-down" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
       <path class="" fill="currentColor" d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"></path>
-    </svg></button>
+    </svg>
+  </button>
   <div class="py-2 px-4">
     <div>Inner Content</div>
   </div>


### PR DESCRIPTION
feat(ui): improve map components and introduce Command Center dashboard

- Added `removeLegend` prop to `SimpleMap.vue` to control legend visibility.
- Refactored `WorkTypeMap.vue` to remove unused `ref` and simplify map initialization.
- Enhanced `AccordionItem.vue` with `iconPosition` and `startOpen` props for improved flexibility.
- Introduced `CommandCenterDashboard.vue` to display affiliated teams and related statistics.
- Updated `Team.ts` model to include `organization` field.
- Added `TeamCompletion.vue` to visualize team completion metrics in dashboards.
- Conditional API calls in `Affiliates.vue` to optimize network requests.
- Updated routing to include the new Command Center dashboard.

chore: Better global error handling for axios calls