### PR TITLE
feat: add query parameters to getAffiliates API call

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,8 +65,11 @@ axios.defaults.withCredentials = true;
 axios.interceptors.response.use(
   (response) => response,
   (error) => {
-    // Here, you can ensure that Axios always throws an AxiosError
-    if (error instanceof AxiosError) {
+    if (
+      error instanceof AxiosError &&
+      error.response?.status !== 403 &&
+      error.response?.status !== 401
+    ) {
       return getAndToastErrorMessage(error);
     }
   },

--- a/src/pages/dashboards/CommandCenterDashboard.vue
+++ b/src/pages/dashboards/CommandCenterDashboard.vue
@@ -31,6 +31,12 @@ const { loadingActionItems } = useDashboardActionItems(
 const getAffiliates = async () => {
   const response = await axios.get(
     `${import.meta.env.VITE_APP_API_BASE_URL}/affiliated_teams`,
+    {
+      params: {
+        limit: 500,
+        incident: currentIncidentId.value,
+      },
+    },
   );
   affiliatedTeams.value = response.data.results;
 


### PR DESCRIPTION
Include 'limit' and 'incident' as parameters to refine the API request, thereby enhancing the relevance and efficiency of fetched data. This update helps in limiting the results and associating them with the current incident.