### PR TITLE
fix: ensure numeric casting for stats and phone counts

### DIFF
--- a/src/components/phone/GeneralStats.vue
+++ b/src/components/phone/GeneralStats.vue
@@ -314,8 +314,8 @@ export default defineComponent({
 
     const allUsersInQueue = computed(() => {
       return (
-        (stats.value.active || 0) +
-        (stats.value.inQueue || 0) +
+        (Number(stats.value.active) || 0) +
+        (Number(stats.value.inQueue) || 0) +
         remainingCallbacks.value +
         remainingCalldowns.value
       );

--- a/src/models/PhoneOutbound.ts
+++ b/src/models/PhoneOutbound.ts
@@ -105,7 +105,7 @@ export default class PhoneOutbound extends CCUModel {
           const {
             response: { data },
           } = phoneOutbound;
-          return data.count;
+          return Number(data.count);
         } catch (error) {
           console.log(error);
         }
@@ -118,7 +118,7 @@ export default class PhoneOutbound extends CCUModel {
           const {
             response: { data },
           } = phoneOutbound;
-          return data.count;
+          return Number(data.count);
         } catch (error) {
           console.log(error);
         }


### PR DESCRIPTION
Convert string values to numbers in GeneralStats.vue and PhoneOutbound.ts to prevent potential type issues. This will enhance data reliability and prevent type errors during computations.