### PR TITLE
feat: add map layer toggle button

### DIFF
--- a/src/components/SimpleMap.vue
+++ b/src/components/SimpleMap.vue
@@ -90,6 +90,21 @@
         "
         class="w-8 h-8 border border-crisiscleanup-dark-100 my-1 bg-white shadow-xl text-crisiscleanup-dark-400"
       />
+      <base-button
+        v-if="showMapLayerToggle"
+        text=""
+        data-testid="testToggleMapTypeButton"
+        icon="map"
+        icon-size="xs"
+        :title="$t('~~Toggle Map Type')"
+        :alt="$t('~~Toggle Map Type')"
+        :action="
+          () => {
+            $emit('onToggleMapType');
+          }
+        "
+        class="w-8 h-8 border-crisiscleanup-dark-100 border-t border-l border-r border-b bg-white shadow-xl text-xl text-crisiscleanup-dark-400 mt-4"
+      />
     </div>
     <WorksiteLegend
       v-if="(showZoomButtons && !removeLegend) || showLegend"
@@ -127,6 +142,9 @@ export default defineComponent({
     availableWorkTypes: {
       type: Object,
       default: () => ({}),
+    },
+    showMapLayerToggle: {
+      type: Boolean,
     },
   },
 });

--- a/src/pages/Work.vue
+++ b/src/pages/Work.vue
@@ -7,6 +7,7 @@
         :map-loading="mapLoading"
         data-testid="testSimpleMapdiv"
         show-zoom-buttons
+        show-map-layer-toggle
         :available-work-types="availableWorkTypes"
         class="mb-16"
         zoom-buttons-class="mt-20"
@@ -14,6 +15,7 @@
         @on-zoom-out="zoomOut"
         @on-zoom-incident-center="goToIncidentCenter"
         @on-zoom-interactive="goToInteractive"
+        @on-toggle-map-type="toggleMapType"
       />
       <WorksitePhotoMap
         v-else-if="showingPhotoMap && caseImages.length > 0"
@@ -549,11 +551,13 @@
               :map-loading="mapLoading"
               data-testid="testSimpleMapdiv"
               show-zoom-buttons
+              show-map-layer-toggle
               :available-work-types="availableWorkTypes"
               @on-zoom-in="zoomIn"
               @on-zoom-out="zoomOut"
               @on-zoom-incident-center="goToIncidentCenter"
               @on-zoom-interactive="goToInteractive"
+              @on-toggle-map-type="toggleMapType"
             />
             <WorksitePhotoMap
               v-else-if="showingPhotoMap && caseImages.length > 0"
@@ -1654,6 +1658,10 @@ export default defineComponent({
       mapUtils?.getMap().setView(getIncidentCenter(), INTERACTIVE_ZOOM_LEVEL);
     }
 
+    function toggleMapType() {
+      mapUtils?.switchTileLayer();
+    }
+
     function onSelectionChanged(selectedItems: Set<number>) {
       selectedTableItems.value = selectedItems;
     }
@@ -2165,6 +2173,7 @@ export default defineComponent({
       collapsedUtilityBar,
       goToIncidentCenter,
       goToInteractive,
+      toggleMapType,
       reloadCase,
       availableWorkTypes,
       applyLocation,


### PR DESCRIPTION
- Add toggle button for changing map layers in SimpleMap.vue
- Introduce `showMapLayerToggle` prop to control visibility of the button
- Implement `toggleMapType` method in Work.vue to handle layer switching
- Enhance `useWorksiteMap.ts` with functionality to switch between multiple map layers