### PR TITLE
feat: update work type claiming logic

### DIFF
--- a/src/components/work/WorksiteView.vue
+++ b/src/components/work/WorksiteView.vue
@@ -543,8 +543,11 @@ export default defineComponent({
 
     const workTypesClaimedByOrganization = computed(() => {
       if (worksite.value) {
-        return worksite.value.work_types.filter((type) =>
-          currentUser.value.organization.affiliates.includes(type.claimed_by),
+        return worksite.value.work_types.filter(
+          (type) =>
+            currentUser.value.organization.affiliates.includes(
+              type.claimed_by,
+            ) || type.claimed_by === currentUser.value.organization.id,
         );
       }
 
@@ -558,7 +561,8 @@ export default defineComponent({
             type.claimed_by &&
             !currentUser.value.organization.affiliates.includes(
               type.claimed_by,
-            ),
+            ) &&
+            type.claimed_by !== currentUser.value.organization.id,
         );
         return groupBy(list, 'claimed_by');
       }


### PR DESCRIPTION
- Include current organization's ID when filtering work types claimed by organization
- Exclude current organization's ID when filtering work types not claimed by affiliates