### PR TITLE
refactor(phone): remove unused data-prefill prop in PhoneSystem.vue

### DIFF
--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -431,7 +431,6 @@
           :incident-id="String(currentIncidentId)"
           :worksite-id="worksiteId"
           disable-claim-and-save
-          :data-prefill="prefillData"
           :is-editing="isEditing"
           class="border shadow"
           @jump-to-case="jumpToCase"
@@ -692,7 +691,6 @@
             :incident-id="String(currentIncidentId)"
             :worksite-id="worksiteId"
             disable-claim-and-save
-            :data-prefill="prefillData"
             :is-editing="isEditing"
             class="border shadow"
             @jump-to-case="jumpToCase"

--- a/test/unit/models/Organization.test.ts
+++ b/test/unit/models/Organization.test.ts
@@ -103,6 +103,7 @@ describe('models > Organization', () => {
         },
         "deleteFile": [Function],
         "model": [Function],
+        "notify": [Function],
         "reject": [Function],
       }
     `);


### PR DESCRIPTION
- Removed the 'data-prefill' prop from the PremadeComponent at index 431
- Removed the 'data-prefill' prop from the PremadeComponent at index 692