### PR TITLE
fix(hooks): fix bug with response area worksites filtering not showing correct filtered dots bc of texture caching error

### DIFF
--- a/src/hooks/worksite/useRenderedMarkers.ts
+++ b/src/hooks/worksite/useRenderedMarkers.ts
@@ -1,5 +1,5 @@
 import { Sprite, Texture } from 'pixi.js';
-// eslint-disable-next-line import/default
+
 import KDBush from 'kdbush';
 import * as turf from '@turf/turf';
 import type * as L from 'leaflet';
@@ -89,10 +89,11 @@ export default (
                 ? fillColor
                 : 'white',
           );
-        let texture = textureMap[fillColor];
+        const svgTextureCacheKey = `${fillColor}_${isFilteredMarker}_${isVisitedMarker}`;
+        let texture = textureMap[svgTextureCacheKey];
         if (!texture) {
-          textureMap[fillColor] = Texture.from(svg);
-          texture = textureMap[fillColor];
+          textureMap[svgTextureCacheKey] = Texture.from(svg);
+          texture = textureMap[svgTextureCacheKey];
         }
 
         sprite.texture = texture;


### PR DESCRIPTION
<!--
Provide a general summary of your changes in the title above

NOTE: Please uncomment (Ctrl/Cmd + /) the header lines if
you have that information about the pull request
-->

<!--
- Describe your changes in detail
- What does this pull request add/fix? Explain your changes.
-->

## Description

On work page, when user selects a filter for organization response area, the dots on
the map look the same. The filtered out dots have lower opacity but they have same texture.
This was caused by having same cache key with texture caching for filtered and visited worksites.

### Current Behavior

![image](https://github.com/user-attachments/assets/6dee0b71-6f97-457f-a9e2-581399af3f88)

### New Behavior

![image](https://github.com/user-attachments/assets/33117795-c8cb-4e2c-8774-d0a697acd777)

<!--
- Screenshots
-->

## Screenshots

<!--
- This project only accepts pull requests related to open issues
- If suggesting a new feature or change, please discuss it in an issue first
- Does your pull request close any issue? If so, please provide a link to the issue.
- If your pull request references an issue, please provide a link to the issue.
-->

## Related Issue

<!--
- Why is this change required?
- What problem does it solve?
-->
<!-- ## Motivation and Context -->

<!--
- What types of changes does your code introduce?
- Put an `x` in all the boxes that apply:
-->

## Pull Request Type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation changes

<!--
- Go over all the following points, and put an `x` in all the boxes that apply.
- If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact of your change below. -->

<!--
- Provide additional context if necessary.
- Examples: version, OS, Browser, Other environment information, error logs, etc.
-->
<!-- ## Additional Context -->
