### PR TITLE
fix: render carrier remediation with HTML

### DIFF
--- a/src/components/phone/PhoneDoctor.vue
+++ b/src/components/phone/PhoneDoctor.vue
@@ -1080,7 +1080,7 @@ onMounted(() => {
             {{ $t(formatCmsItem(option.title)) }}
           </template>
         </base-select>
-        {{ $t(formatCmsItem(carrierRemediation)) }}
+        <span v-html="$t(formatCmsItem(carrierRemediation))"> </span>
       </div>
 
       <base-button


### PR DESCRIPTION
- Replace text interpolation with v-html to render carrierRemediation with HTML in PhoneDoctor.vue