### PR TITLE
feat: enhance WorksiteFilters and location filter logic

### DIFF
--- a/src/components/phone/CurrentCall.vue
+++ b/src/components/phone/CurrentCall.vue
@@ -48,8 +48,10 @@ watch(
   () => call.value,
   (newValue) => {
     if (newValue && newValue.dnis1) {
+      // Get the worksites for the phone number within the last 60 days
       const params = {
         phone1_dnis: newValue.dnis1,
+        created_at__gte: moment().subtract(60, 'days').toISOString(),
       };
       Worksite.api()
         .get(`/worksites?${getQueryString(params)}`, {

--- a/test/unit/utils/data_filters/WorksiteLocationsFilter.test.ts
+++ b/test/unit/utils/data_filters/WorksiteLocationsFilter.test.ts
@@ -7,6 +7,8 @@ vi.mock('@/hooks', () => ({
       value: {
         organization: {
           id: 'organization_id',
+          primary_location: 'primary_location',
+          secondary_location: 'secondary_location',
         },
       },
     },
@@ -23,9 +25,7 @@ describe('UserLocationsFilter', () => {
     });
     const packed = userLocationsFilter.packFunction();
     expect(packed).toEqual({
-      organization_primary_location: 'organization_id',
-      organization_secondary_location: 'organization_id',
-      locations: 'location1',
+      locations: 'primary_location,secondary_location,location1',
     });
   });
 


### PR DESCRIPTION
- add primary and secondary location fields in WorksiteLocationsFilter.test.ts
- consolidate locations into a single 'locations' key in WorksiteLocationsFilter.ts
- update CurrentCall.vue to fetch worksites for the phone number within the last 60 days
- enhance WorksiteFilters.vue with a multi-select for search locations and location types
- implement search functionality for locations in WorksiteFilters.vue