### PR TITLE
feat: add pagination support to load cases

### DIFF
--- a/src/pages/Work.vue
+++ b/src/pages/Work.vue
@@ -982,7 +982,7 @@ import Worksite from '../models/Worksite';
 import CaseHistory from '../components/work/CaseHistory.vue';
 import {
   loadCaseImagesCached,
-  loadCasesCached,
+  loadCasesCachedWithPagination,
   loadUserLocations,
 } from '../utils/worksite';
 import { averageGeolocation, getUserLocationLayer } from '../utils/map';
@@ -1256,7 +1256,7 @@ export default defineComponent({
 
     async function getWorksites() {
       mapLoading.value = true;
-      const response = await loadCasesCached({
+      const response = await loadCasesCachedWithPagination({
         ...worksiteQuery.value,
       });
       mapLoading.value = false;
@@ -1274,7 +1274,7 @@ export default defineComponent({
 
     async function getAllWorksites() {
       mapLoading.value = true;
-      const response = await loadCasesCached({
+      const response = await loadCasesCachedWithPagination({
         incident: currentIncidentId.value,
       });
       mapLoading.value = false;

--- a/src/pages/phone/PhoneSystem.vue
+++ b/src/pages/phone/PhoneSystem.vue
@@ -540,7 +540,7 @@ import useDialogs from '../../hooks/useDialogs';
 import useConnectFirst from '../../hooks/useConnectFirst';
 import User from '../../models/User';
 import WorksiteForm from '../../components/work/WorksiteForm.vue';
-import { loadCasesCached } from '@/utils/worksite';
+import { loadCasesCachedWithPagination } from '@/utils/worksite';
 import { getErrorMessage } from '@/utils/errors';
 import usePhoneService from '@/hooks/phone/usePhoneService';
 import WorksiteTable from '@/components/work/WorksiteTable.vue';
@@ -1120,7 +1120,7 @@ export default defineComponent({
 
     async function getWorksites() {
       mapLoading.value = true;
-      const response = await loadCasesCached({
+      const response = await loadCasesCachedWithPagination({
         incident: currentIncidentId.value,
       });
       mapLoading.value = false;

--- a/src/utils/dashboard.ts
+++ b/src/utils/dashboard.ts
@@ -5,7 +5,7 @@ import { getApiUrl } from '@/utils/helpers';
 import Worksite from '@/models/Worksite';
 import { getQueryString } from '@/utils/urls';
 import InvitationRequest from '@/models/InvitationRequest';
-import { loadCasesCached } from '@/utils/worksite';
+import { loadCasesCachedWithPagination } from '@/utils/worksite';
 import User from '@/models/User';
 import Organization from '@/models/Organization';
 
@@ -73,7 +73,7 @@ async function getInvitationRequests() {
 }
 
 async function getWorksites(incident) {
-  const response = await loadCasesCached({
+  const response = await loadCasesCachedWithPagination({
     incident: incident,
   });
   return response.results;


### PR DESCRIPTION
- Refactor `loadCasesCached` to `loadCasesCachedWithPagination` for enhanced pagination support.
- Implement `loadCasesPaginated` function to handle API requests with pagination.
- Update method invocations in PhoneSystem.vue, Work.vue, and dashboard.ts to use the new `loadCasesCachedWithPagination`.
- Improve cache reconciliation logic to ensure data consistency.