### PR TITLE
feat: add functionality to send emails from WorksiteForm

### DIFF
--- a/src/components/work/WorksiteForm.vue
+++ b/src/components/work/WorksiteForm.vue
@@ -155,7 +155,11 @@
           selector="js-worksite-email"
           size="large"
           :placeholder="$t('formLabels.email')"
+          :fa-icon="
+            currentIncident.auto_contact && worksite.id ? 'envelope' : null
+          "
           @update:model-value="(v) => updateWorksite(v, 'email')"
+          @icon-clicked="() => sendEmail(worksite.email)"
         />
       </div>
       <div class="form-field">
@@ -941,6 +945,32 @@ export default defineComponent({
       }
     }
 
+    async function sendEmail(email: string) {
+      try {
+        const result = await confirm({
+          title: t(`actions.confirm`),
+          content: t(`caseForm.confirm_send_email`),
+          actions: {
+            no: {
+              text: t('actions.cancel'),
+              type: 'outline',
+              buttonClass: 'border border-black',
+            },
+            yes: {
+              text: t('actions.send_message'),
+              type: 'solid',
+            },
+          },
+        });
+        if (result === 'yes') {
+          await Worksite.api().sendSurvivorEmail(worksite.value.id, email);
+          $toasted.success(t('caseForm.email_sent'));
+        }
+      } catch (error) {
+        $toasted.error(getErrorMessage(error));
+      }
+    }
+
     async function findPotentialGeocode() {
       const geocodeKeys = ['address', 'city', 'county', 'state', 'postal_code'];
       const nonEmptyKeys = geocodeKeys.filter((key) =>
@@ -1713,13 +1743,8 @@ export default defineComponent({
       getSectionCount,
       clearWorksiteStorage,
       statusValueChange,
-      reloadWorksite,
       sendSms,
-      findPotentialGeocode,
-      checkGeocodeLocation,
       potentialIncidents,
-      getPotentialIncidents,
-      updateWorksiteFields,
       unlockLocationFields,
       clearLocationFields,
       collapseGreenPhoneSection,
@@ -1762,6 +1787,7 @@ export default defineComponent({
       hasFormHeaderContent,
       supportedLanguages,
       emitManualDialer,
+      sendEmail,
     };
   },
 });

--- a/src/models/Worksite.ts
+++ b/src/models/Worksite.ts
@@ -413,6 +413,15 @@ export default class Worksite extends CCUModel {
           { save: false },
         );
       },
+      sendSurvivorEmail(id, email) {
+        return this.post(
+          `/worksites/${id}/send_survivor_email`,
+          {
+            email,
+          },
+          { save: false },
+        );
+      },
       searchWorksites(search, incident) {
         return this.get(
           `/worksites?fields=id,name,address,case_number,postal_code,city,state,incident,work_types&limit=5&search=${search}&incident=${incident}`,


### PR DESCRIPTION
- Implemented `sendEmail` method in WorksiteForm for sending emails to survivors.
- Added email icon to the email input field, dynamically displayed based on conditions.
- Integrated confirmation dialog when triggering email sending.
- Added `sendSurvivorEmail` API method in Worksite model to handle email requests.