### PR TITLE
fix: update API endpoint and parameters for incident loading in Admin SentimentAnalysis

### DIFF
--- a/src/pages/admin/AdminSentimentAnalysis.vue
+++ b/src/pages/admin/AdminSentimentAnalysis.vue
@@ -671,7 +671,14 @@ const batchColumns = makeTableColumns([
 const loadIncidents = async () => {
   try {
     const response = await axios.get(
-      `${import.meta.env.VITE_APP_API_BASE_URL}/incidents`,
+      `${import.meta.env.VITE_APP_API_BASE_URL}/incidents_list`,
+      {
+        params: {
+          fields: 'id,name,short_name,geofence,locations',
+          limit: 200,
+          sort: '-start_at',
+        },
+      },
     );
     incidents.value = response.data.results || response.data;
   } catch (error) {


### PR DESCRIPTION
- Changed the API endpoint from `/incidents` to `/incidents_list` to align with the new backend structure.
- Added query parameters to limit the fields fetched, set a limit of 200 results, and sort by the `start_at` field in descending order.
- This update improves data retrieval efficiency and ensures the component receives the necessary information for display.